### PR TITLE
fix: downgrade ubuntu version

### DIFF
--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -33,11 +33,11 @@ jobs:
         # TODO Working Linux 32-bit packaging
         # TODO CTest & coverage workflow implement
         arch: [32, 64]
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         compiler: [gcc, clang]
         build_type: [Debug, Release]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             build_type: Release
             compiler: gcc
             arch: 64


### PR DESCRIPTION
If the AppImage is built with a too recent version of the glibc, it will not run on an older system.
For more details, see https://docs.appimage.org/introduction/concepts.html#build-on-old-systems-run-on-newer-systems
Not tested at the moment.